### PR TITLE
Add maximum index in QR code

### DIFF
--- a/src/sync-test-dock.hpp
+++ b/src/sync-test-dock.hpp
@@ -31,6 +31,9 @@ private:
 	int missed_audio_ix;
 	int received_video_ix;
 	int received_audio_ix;
+	int received_video_index_max = 0;
+	int received_audio_index_max = 0;
+	int audio_index_max = 0;
 
 private:
 	void on_start_stop();

--- a/src/sync-test-output.cpp
+++ b/src/sync-test-output.cpp
@@ -56,6 +56,8 @@ struct st_audio_buffer
 
 	std::pair<int32_t, int32_t> sum(size_t n_from_last)
 	{
+		if (buffer.size() <= 0)
+			return std::make_pair(0, 0);
 		if (n_from_last >= buffer.size())
 			return buffer[0];
 		return buffer[buffer.size() - n_from_last - 1];
@@ -69,7 +71,7 @@ std::pair<int32_t, int32_t> operator-(std::pair<int32_t, int32_t> a, std::pair<i
 
 std::complex<float> int16_to_complex(std::pair<int32_t, int32_t> x)
 {
-	return std::complex<float>((float)x.first, (float)x.second) / 32767.0f;
+	return std::complex<float>((float)x.first / 32768.0f, (float)x.second / 32768.0f);
 }
 
 struct corner_type

--- a/src/sync-test-output.hpp
+++ b/src/sync-test-output.hpp
@@ -100,4 +100,5 @@ struct audio_marker_found_s
 	uint64_t timestamp;
 	int index;
 	float score;
+	uint32_t index_max;
 };

--- a/src/sync-test-output.hpp
+++ b/src/sync-test-output.hpp
@@ -8,6 +8,7 @@ struct st_qr_data
 	uint32_t c = 0;
 	uint32_t q_ms = 0;
 	uint32_t index = -1;
+	uint32_t index_max = 256;
 	uint32_t type_flags = 0;
 	bool valid = 0;
 
@@ -34,6 +35,9 @@ struct st_qr_data
 			return true;
 		case 'i':
 			index = (uint32_t)atoi(val);
+			return true;
+		case 'I':
+			index_max = (uint32_t)atoi(val);
 			return true;
 		case 't':
 			type_flags = (uint32_t)atoi(val);

--- a/tool/videogen.py
+++ b/tool/videogen.py
@@ -235,8 +235,7 @@ class Pattern:
             raise ValueError(f'Too large start_offset; {start_offset}, expect <= {n_blank_begin}')
         i = 0
         buffer = b'\x00\x00' * (n_blank_begin - start_offset)
-        sym_prev = -1
-        sym = -1
+        sym_prev, sym, sym_next = -1, -1, -1
         i_data_prev = -1
         while i < n_pattern:
             phase = i * 2 * math.pi * f / ctx.ar


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Add maximum index in the QR code.

When calculating the statistic information such as number of missed indexes, the maximum index is used.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

OS: Fedora 39

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
